### PR TITLE
Add "#include <limits>" to fix compile time error with gcc 11.

### DIFF
--- a/renderer/fhm_location.cpp
+++ b/renderer/fhm_location.cpp
@@ -19,6 +19,8 @@
 #include "util/location.h"
 #include "util/xml.h"
 
+#include <limits>
+
 #include <math.h>
 #include <stdint.h>
 


### PR DESCRIPTION
This commit adds `#include <limits>` to fix a compile time error on Linux with GCC 11.